### PR TITLE
Fix type import and tailwind plugin

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import type { ReactNode } from 'react'
 import './globals.css'
 
 export const metadata: Metadata = {
@@ -10,7 +11,7 @@ export const metadata: Metadata = {
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode
+  children: ReactNode
 }>) {
   return (
     <html lang="en">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 const config: Config = {
     darkMode: ["class"],
@@ -91,6 +92,6 @@ const config: Config = {
   		}
   	}
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [animate],
 };
 export default config;


### PR DESCRIPTION
## Summary
- fix React type import in `app/layout.tsx`
- update tailwind config to use ESM plugin import

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'next', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684ba86430e0832b8f6e1ec791e0733e