### PR TITLE
Fix tool reverting in tldraw

### DIFF
--- a/components/whiteboard.tsx
+++ b/components/whiteboard.tsx
@@ -1,7 +1,12 @@
 "use client"
 
 import * as React from "react"
-import { Tldraw, useEditor, type TLStoreSnapshot, type TLUiOverrides } from "@tldraw/tldraw"
+import {
+  Tldraw,
+  useEditor,
+  type TLStoreSnapshot,
+  type TLUiOverrides,
+} from "@tldraw/tldraw"
 import "@tldraw/tldraw/tldraw.css"
 import { useNotesStore } from "@/lib/store"
 import type { Note } from "@/lib/types"
@@ -19,6 +24,14 @@ function ToolLock() {
     editor.updateInstanceState({ isToolLocked: true })
   }, [editor])
   return null
+}
+
+function useInitialSnapshot(snapshot: TLStoreSnapshot) {
+  const ref = React.useRef<TLStoreSnapshot | null>(null)
+  if (!ref.current) {
+    ref.current = snapshot
+  }
+  return ref.current
 }
 
 interface WhiteboardProps {
@@ -68,11 +81,12 @@ function SaveStatus({ noteId }: { noteId: string }) {
  * The main whiteboard component that wraps the Tldraw editor.
  */
 export function Whiteboard({ note }: WhiteboardProps) {
+  const initialSnapshot = useInitialSnapshot(note.content as TLStoreSnapshot)
   return (
     <div className="relative h-full w-full">
       <Tldraw
         // Directly pass the note's content. This was the state before the "blink fix".
-        snapshot={note.content as TLStoreSnapshot}
+        snapshot={initialSnapshot}
         forceMobile={false}
         // Apply the overrides to disable keyboard shortcuts
         overrides={uiOverrides}

--- a/components/whiteboard.tsx
+++ b/components/whiteboard.tsx
@@ -13,6 +13,14 @@ const uiOverrides: TLUiOverrides = {
   },
 }
 
+function ToolLock() {
+  const editor = useEditor()
+  React.useEffect(() => {
+    editor.updateInstanceState({ isToolLocked: true })
+  }, [editor])
+  return null
+}
+
 interface WhiteboardProps {
   note: Note
 }
@@ -70,6 +78,7 @@ export function Whiteboard({ note }: WhiteboardProps) {
         overrides={uiOverrides}
       >
         <SaveStatus noteId={note.id} />
+        <ToolLock />
       </Tldraw>
     </div>
   )


### PR DESCRIPTION
## Summary
- keep the active tool locked in Tldraw so it doesn't revert to the view tool

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684baaf7c8d4832bbfa5c553d506cf24